### PR TITLE
Clarify supported models for `chatCompletions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This handler supports both the *GPT-3.5* and *GPT-4* models:
 
 #### GPT-3.5
 
-Supported [GPT-3.5 models](https://platform.openai.com/docs/models/gpt-3-5) include `gpt-3.5-turbo`, `text-davinci-003`, `text-davinci-002` and more.
+Supported [GPT-3.5 models](https://platform.openai.com/docs/models/gpt-3-5) include `gpt-3.5-turbo` and more.
 
 #### GPT-4
 


### PR DESCRIPTION
As per https://platform.openai.com/docs/models/model-endpoint-compatibility, `text-davinci-003`, `text-davinci-002` are **not** supported by the `chatCompletions` endpoint.

Thank you to @jacksutherland for identifying this error.

Ref: https://github.com/tectalichq/public-openai-client-php/discussions/25#discussioncomment-5909869